### PR TITLE
remove unnecessary gproj parameter

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -112,6 +112,6 @@ else:
 
     config_path = CONFIG_GENERATED
 
-launch = f"{os.environ['ARMA_BINARY']} -gproj ./addons/data/ArmaReforger.gproj -config {config_path} -backendlog -nothrow -profile {os.environ['ARMA_PROFILE']} {os.environ['ARMA_PARAMS']}"
+launch = f"{os.environ['ARMA_BINARY']} -config {config_path} -backendlog -nothrow -profile {os.environ['ARMA_PROFILE']} {os.environ['ARMA_PARAMS']}"
 print(launch, flush=True)
 os.system(launch)


### PR DESCRIPTION
This parameter is unnecessary and breaks loaded addons sometimes (I really don't know why)